### PR TITLE
Add debug logs

### DIFF
--- a/internal/ui/logger.go
+++ b/internal/ui/logger.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+func redactedFile(f *fileDesc) string {
+	if f == nil {
+		return "null"
+	}
+	redactedUri := "parsing-error-" + strconv.Itoa(f.id)
+	splitIdx := strings.Index(f.uri, ":")
+	if splitIdx != -1 {
+		redactedUri = f.uri[:splitIdx+1] + "redacted-" + strconv.Itoa(f.id)
+	}
+	return "{\"Uri\":\"" + redactedUri + "\"}"
+}
+
+func redactedString(s string) string {
+	if len(s) > 0 {
+		return "non-empty-string"
+	}
+	return ""
+}
+
+func stateJson(state State) string {
+	keyfiles := []string{}
+	for _, k := range state.Keyfiles {
+		keyfiles = append(keyfiles, redactedFile(&k))
+	}
+	keyfilesJson := "[" + strings.Join(keyfiles, ",") + "]"
+	fields := []string{
+		"\"Input\":" + redactedFile(state.Input()),
+		"\"SaveAs\":" + redactedFile(state.Input()),
+		"\"Comments\":" + redactedString(state.Comments),
+		"\"ReedSolomon\":" + strconv.FormatBool(state.ReedSolomon),
+		"\"Deniability\":" + strconv.FormatBool(state.Deniability),
+		"\"Paranoid\":" + strconv.FormatBool(state.Paranoid),
+		"\"OrderedKeyfiles\":\"redacted\"",
+		"\"Keyfiles\":" + keyfilesJson,
+		"\"Password\":" + redactedString(state.Password),
+		"\"ConfirmPassword\":" + redactedString(state.ConfirmPassword),
+	}
+	return "{" + strings.Join(fields, ",") + "}"
+}
+
+type logLine struct {
+	time   string
+	action string
+	state  string
+	err    string
+}
+
+type Logger struct {
+	lines []logLine
+}
+
+func (l *Logger) Log(action string, state State, err error) {
+	line := logLine{
+		time:   time.Now().Format("15:04:05.1234"),
+		action: action,
+		state:  stateJson(state),
+		err:    err.Error(),
+	}
+	l.lines = append(l.lines, line)
+}
+
+func (l *Logger) CsvString() string {
+	logLines := []string{"Time,Action,State,Error"}
+	for _, line := range l.lines {
+		fields := []string{
+			"\"" + line.time + "\"",
+			"\"" + line.action + "\"",
+			"\"" + line.state + "\"",
+			"\"" + line.err + "\"",
+		}
+		logLines = append(logLines, strings.Join(fields, ","))
+	}
+	return strings.Join(logLines, "\n")
+}

--- a/internal/ui/logger.go
+++ b/internal/ui/logger.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -52,6 +53,7 @@ type logLine struct {
 
 type Logger struct {
 	lines []logLine
+	mutex sync.Mutex
 }
 
 func (l *Logger) Log(action string, state State, err error) {
@@ -65,6 +67,8 @@ func (l *Logger) Log(action string, state State, err error) {
 		state:  stateJson(state),
 		err:    errMsg,
 	}
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
 	l.lines = append(l.lines, line)
 }
 

--- a/internal/ui/logger.go
+++ b/internal/ui/logger.go
@@ -33,15 +33,12 @@ func stateJson(state State) string {
 	keyfilesJson := "[" + strings.Join(keyfiles, ",") + "]"
 	fields := []string{
 		"\"Input\":" + redactedFile(state.Input()),
-		"\"SaveAs\":" + redactedFile(state.Input()),
-		"\"Comments\":" + redactedString(state.Comments),
+		"\"SaveAs\":" + redactedFile(state.SaveAs),
+		"\"Comments\":\"" + redactedString(state.Comments) + "\"",
 		"\"ReedSolomon\":" + strconv.FormatBool(state.ReedSolomon),
 		"\"Deniability\":" + strconv.FormatBool(state.Deniability),
 		"\"Paranoid\":" + strconv.FormatBool(state.Paranoid),
-		"\"OrderedKeyfiles\":\"redacted\"",
 		"\"Keyfiles\":" + keyfilesJson,
-		"\"Password\":" + redactedString(state.Password),
-		"\"ConfirmPassword\":" + redactedString(state.ConfirmPassword),
 	}
 	return "{" + strings.Join(fields, ",") + "}"
 }
@@ -58,11 +55,15 @@ type Logger struct {
 }
 
 func (l *Logger) Log(action string, state State, err error) {
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
 	line := logLine{
-		time:   time.Now().Format("15:04:05.1234"),
+		time:   time.Now().Format("15:04:05.000"),
 		action: action,
 		state:  stateJson(state),
-		err:    err.Error(),
+		err:    errMsg,
 	}
 	l.lines = append(l.lines, line)
 }

--- a/internal/ui/logger.go
+++ b/internal/ui/logger.go
@@ -68,7 +68,7 @@ func (l *Logger) Log(action string, state State, err error) {
 }
 
 func (l *Logger) CsvString() string {
-	logLines := []string{"Time,Action,State,Error"}
+	logLines := []string{"Time,Action,State,Error," + PicoGoVersion}
 	for _, line := range l.lines {
 		fields := []string{
 			"\"" + line.time + "\"",

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -1,0 +1,117 @@
+package ui
+
+import (
+	"strings"
+	"sync"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/storage"
+
+	"github.com/picocrypt/picogo/internal/encryption"
+)
+
+var fileDescCount int
+var fileDescMutex sync.Mutex
+
+func nextFileDescID() int {
+	fileDescMutex.Lock()
+	defer fileDescMutex.Unlock()
+	fileDescCount++
+	return fileDescCount
+}
+
+type fileDesc struct {
+	name string
+	uri  string
+	id   int
+}
+
+func (f *fileDesc) Name() string {
+	return f.name
+}
+
+func (f *fileDesc) Uri() string {
+	return f.uri
+}
+
+func NewFileDesc(uri fyne.URI) fileDesc {
+	return fileDesc{
+		name: uri.Name(),
+		uri:  uri.String(),
+		id:   nextFileDescID(),
+	}
+}
+
+type State struct {
+	input           *fileDesc
+	SaveAs          *fileDesc
+	Comments        string
+	ReedSolomon     bool
+	Deniability     bool
+	Paranoid        bool
+	OrderedKeyfiles bool
+	Keyfiles        []fileDesc
+	Password        string
+	ConfirmPassword string
+}
+
+func (s *State) Input() *fileDesc {
+	return s.input
+}
+
+func (s *State) IsEncrypting() bool {
+	if s.input == nil {
+		return false
+	}
+	return strings.HasSuffix(s.input.Name(), ".pcv")
+}
+
+func (s *State) IsDecrypting() bool {
+	if s.input == nil {
+		return false
+	}
+	return !strings.HasSuffix(s.input.Name(), ".pcv")
+}
+
+func (s *State) SetInput(input fyne.URI) error {
+	s.Clear()
+	inputDesc := NewFileDesc(input)
+	s.input = &inputDesc
+
+	if s.IsDecrypting() {
+		reader, err := storage.Reader(input)
+		if reader != nil {
+			defer reader.Close()
+		}
+		if err != nil {
+			return err
+		}
+		settings, err := encryption.GetEncryptionSettings(reader)
+		if err != nil {
+			return err
+		}
+		s.Comments = settings.Comments
+		s.ReedSolomon = settings.ReedSolomon
+		s.Deniability = settings.Deniability
+		s.Paranoid = settings.Paranoid
+		s.OrderedKeyfiles = settings.OrderedKf
+	}
+	return nil
+}
+
+func (s *State) AddKeyfile(uri fyne.URI) {
+	s.Keyfiles = append(s.Keyfiles, NewFileDesc(uri))
+}
+
+func (s *State) Clear() {
+	s.input = nil
+	s.SaveAs = nil
+	s.Comments = ""
+	s.ReedSolomon = false
+	s.Deniability = false
+	s.Paranoid = false
+	s.OrderedKeyfiles = false
+	s.Keyfiles = nil
+	s.Password = ""
+	s.ConfirmPassword = ""
+}

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -10,6 +10,8 @@ import (
 	"github.com/picocrypt/picogo/internal/encryption"
 )
 
+const PicoGoVersion = "v0.1.1"
+
 var fileDescCount int
 var fileDescMutex sync.Mutex
 

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 
@@ -86,11 +87,11 @@ func (s *State) SetInput(input fyne.URI) error {
 			defer reader.Close()
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to open file: %w", err)
 		}
 		settings, err := encryption.GetEncryptionSettings(reader)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get encryption settings: %w", err)
 		}
 		s.Comments = settings.Comments
 		s.ReedSolomon = settings.ReedSolomon

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -65,14 +65,14 @@ func (s *State) IsEncrypting() bool {
 	if s.input == nil {
 		return false
 	}
-	return strings.HasSuffix(s.input.Name(), ".pcv")
+	return !strings.HasSuffix(s.input.Name(), ".pcv")
 }
 
 func (s *State) IsDecrypting() bool {
 	if s.input == nil {
 		return false
 	}
-	return !strings.HasSuffix(s.input.Name(), ".pcv")
+	return strings.HasSuffix(s.input.Name(), ".pcv")
 }
 
 func (s *State) SetInput(input fyne.URI) error {

--- a/picogo.go
+++ b/picogo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"image/color"
 	"io"
 	"strconv"
@@ -119,7 +120,7 @@ func chooseSaveAs(logger *ui.Logger, state *ui.State, window fyne.Window) {
 		}
 		if err != nil {
 			logger.Log("Failed while choosing where to save output", *state, err)
-			dialog.ShowError(err, window)
+			dialog.ShowError(fmt.Errorf("choosing output file: %w", err), window)
 			return
 		}
 		if writer != nil {
@@ -151,7 +152,7 @@ func saveOutput(logger *ui.Logger, state *ui.State, window fyne.Window, app fyne
 	outputURI, err := getOutputURI(app)
 	if err != nil {
 		logger.Log("Get output uri", *state, err)
-		dialog.ShowError(err, window)
+		dialog.ShowError(fmt.Errorf("finding output file: %w", err), window)
 		return
 	}
 	output, err := storage.Reader(outputURI)
@@ -160,7 +161,7 @@ func saveOutput(logger *ui.Logger, state *ui.State, window fyne.Window, app fyne
 	}
 	if err != nil {
 		logger.Log("Get output reader", *state, err)
-		dialog.ShowError(err, window)
+		dialog.ShowError(fmt.Errorf("opening output file: %w", err), window)
 		return
 	}
 	saveAs, err := uriWriteCloser(state.SaveAs.Uri())
@@ -169,7 +170,7 @@ func saveOutput(logger *ui.Logger, state *ui.State, window fyne.Window, app fyne
 	}
 	if err != nil {
 		logger.Log("Get save as writer", *state, err)
-		dialog.ShowError(err, window)
+		dialog.ShowError(fmt.Errorf("opening save-as file: %w", err), window)
 		return
 	}
 	errCh := make(chan error)
@@ -193,12 +194,12 @@ func saveOutput(logger *ui.Logger, state *ui.State, window fyne.Window, app fyne
 			d.Hide()
 			if err != nil {
 				logger.Log("Saving output", *state, err)
-				dialog.ShowError(err, window)
+				dialog.ShowError(fmt.Errorf("copying output: %w", err), window)
 			}
 			err = clearOutputFile(app)
 			if err != nil {
 				logger.Log("Clearing output file", *state, err)
-				dialog.ShowError(err, window)
+				dialog.ShowError(fmt.Errorf("cleaning tmp file: %w", err), window)
 			}
 			return
 		default:
@@ -329,7 +330,7 @@ func encrypt(logger *ui.Logger, state *ui.State, win fyne.Window, app fyne.App) 
 	}
 	logger.Log("Complete encryption", *state, encryptErr)
 	if encryptErr != nil {
-		dialog.ShowError(encryptErr, win)
+		dialog.ShowError(fmt.Errorf("encrypting: %w", encryptErr), win)
 		return
 	}
 	text := widget.NewLabel(state.Input().Name() + " has been encrypted.")
@@ -535,7 +536,7 @@ func makeKeyfileBtn(logger *ui.Logger, state *ui.State, window fyne.Window) *wid
 				}
 				if err != nil {
 					logger.Log("Adding keyfile failed", *state, err)
-					dialog.ShowError(err, window)
+					dialog.ShowError(fmt.Errorf("adding keyfile: %w", err), window)
 					return
 				}
 				if reader != nil {
@@ -555,7 +556,7 @@ func makeKeyfileBtn(logger *ui.Logger, state *ui.State, window fyne.Window) *wid
 				}
 				if err != nil {
 					logger.Log("Creating keyfile failed", *state, err)
-					dialog.ShowError(err, window)
+					dialog.ShowError(fmt.Errorf("creating keyfile: %w", err), window)
 					return
 				}
 				if writer != nil {
@@ -563,13 +564,13 @@ func makeKeyfileBtn(logger *ui.Logger, state *ui.State, window fyne.Window) *wid
 					_, err := rand.Read(data)
 					if err != nil {
 						logger.Log("Creating keyfile data failed", *state, err)
-						dialog.ShowError(err, window)
+						dialog.ShowError(fmt.Errorf("creating keyfile: %w", err), window)
 						return
 					}
 					_, err = writer.Write(data)
 					if err != nil {
 						logger.Log("Writing keyfile failed", *state, err)
-						dialog.ShowError(err, window)
+						dialog.ShowError(fmt.Errorf("writing keyfile: %w", err), window)
 						return
 					}
 					state.AddKeyfile(writer.URI())
@@ -626,7 +627,7 @@ func writeLogs(logger *ui.Logger, window fyne.Window) {
 			defer writer.Close()
 		}
 		if err != nil {
-			dialog.ShowError(err, window)
+			dialog.ShowError(fmt.Errorf("writing logs: %w", err), window)
 			return
 		}
 		if writer != nil {
@@ -683,7 +684,7 @@ func main() {
 			}
 			if err != nil {
 				logger.Log("Choosing file to encrypt/decrypt failed", state, err)
-				dialog.ShowError(err, w)
+				dialog.ShowError(fmt.Errorf("choosing file: %w", err), w)
 				return
 			}
 			if reader == nil {
@@ -693,7 +694,7 @@ func main() {
 			err = state.SetInput(reader.URI())
 			logger.Log("Setting file to encrypt/decrypt", state, err)
 			if err != nil {
-				dialog.ShowError(err, w)
+				dialog.ShowError(fmt.Errorf("choosing file: %w", err), w)
 			}
 		}, w)
 		fd.Show()

--- a/picogo.go
+++ b/picogo.go
@@ -366,7 +366,7 @@ func tryDecrypt(
 	for i := 0; i < len(state.Keyfiles); i++ {
 		r, err := uriReadCloser(state.Keyfiles[i].Uri())
 		if err != nil {
-			logger.Log("tryDecrypt: get keyfile reader "+strconv.Itoa(i), *state, err)
+			logger.Log("Get keyfile reader "+strconv.Itoa(i), *state, err)
 			return false, err
 		}
 		defer r.Close()

--- a/picogo.go
+++ b/picogo.go
@@ -620,7 +620,7 @@ func developmentWarning(win fyne.Window) {
 	}
 }
 
-func writeLogs(logger ui.Logger, window fyne.Window) {
+func writeLogs(logger *ui.Logger, window fyne.Window) {
 	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
 		if writer != nil {
 			defer writer.Close()
@@ -665,7 +665,7 @@ func main() {
 		text.Wrapping = fyne.TextWrapWord
 		dialog.ShowCustomConfirm(title, "Save Logs", "Dismiss", text, func(b bool) {
 			if b {
-				writeLogs(logger, w)
+				writeLogs(&logger, w)
 			}
 		}, w)
 	})

--- a/picogo.go
+++ b/picogo.go
@@ -638,6 +638,21 @@ func developmentWarning(win fyne.Window) {
 	}
 }
 
+func writeLogs(window fyne.Window) {
+	msg := "Test log"
+	dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+		if writer != nil {
+			defer writer.Close()
+		}
+		if err != nil {
+			return
+		}
+		if writer != nil {
+			writer.Write([]byte(msg))
+		}
+	}, window).Show()
+}
+
 func main() {
 	a := app.New()
 	a.Settings().SetTheme(&myTheme{})
@@ -654,9 +669,23 @@ func main() {
 		confirm := dialog.NewInformation(title, message, w)
 		confirm.Show()
 	})
+	logBtn := widget.NewButtonWithIcon("", theme.MailSendIcon(), func() {
+		title := "Save Logs"
+		message := "Save log data to assist with issue reporting. Sensitive data (passwords, file names, etc.) " +
+			"will not be recorded, but you should still review the logs before sharing to ensure you are " +
+			"comfortable with the data being shared."
+		text := widget.NewLabel(message)
+		text.Wrapping = fyne.TextWrapWord
+		dialog.ShowCustomConfirm(title, "Save Logs", "Dismiss", text, func(b bool) {
+			if b {
+				writeLogs(w)
+			}
+		}, w)
+	})
 	info_row := container.New(
 		layout.NewHBoxLayout(),
 		info,
+		logBtn,
 		layout.NewSpacer(),
 	)
 

--- a/picogo.go
+++ b/picogo.go
@@ -626,6 +626,7 @@ func writeLogs(logger ui.Logger, window fyne.Window) {
 			defer writer.Close()
 		}
 		if err != nil {
+			dialog.ShowError(err, window)
 			return
 		}
 		if writer != nil {

--- a/picogo.go
+++ b/picogo.go
@@ -21,9 +21,8 @@ import (
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/picocrypt/picogo/internal/encryption"
+	"github.com/picocrypt/picogo/internal/ui"
 )
-
-var version = "0.1.1"
 
 type myTheme struct{}
 
@@ -662,7 +661,7 @@ func main() {
 	updates := UpdateMethods{}
 
 	info := widget.NewButtonWithIcon("", theme.InfoIcon(), func() {
-		title := "PicoGo v" + version
+		title := "PicoGo " + ui.PicoGoVersion
 		message := "This app is not sponsored or supported by Picocrypt. It is a 3rd party " +
 			"app written to make Picocrypt files more easily accessible on mobile devices.\n\n" +
 			"If you have any problems, please report them so that they can be fixed."

--- a/picogo.go
+++ b/picogo.go
@@ -637,9 +637,8 @@ func developmentWarning(win fyne.Window) {
 	}
 }
 
-func writeLogs(window fyne.Window) {
-	msg := "Test log"
-	dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+func writeLogs(logger ui.Logger, window fyne.Window) {
+	d := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
 		if writer != nil {
 			defer writer.Close()
 		}
@@ -647,15 +646,18 @@ func writeLogs(window fyne.Window) {
 			return
 		}
 		if writer != nil {
-			writer.Write([]byte(msg))
+			writer.Write([]byte(logger.CsvString()))
 		}
-	}, window).Show()
+	}, window)
+	d.SetFileName("picogo-logs.csv")
+	d.Show()
 }
 
 func main() {
 	a := app.New()
 	a.Settings().SetTheme(&myTheme{})
 	w := a.NewWindow("PicoGo")
+	logger := ui.Logger{}
 
 	state := State{}
 	updates := UpdateMethods{}
@@ -677,7 +679,7 @@ func main() {
 		text.Wrapping = fyne.TextWrapWord
 		dialog.ShowCustomConfirm(title, "Save Logs", "Dismiss", text, func(b bool) {
 			if b {
-				writeLogs(w)
+				writeLogs(logger, w)
 			}
 		}, w)
 	})

--- a/picogo.go
+++ b/picogo.go
@@ -191,13 +191,13 @@ func saveOutput(logger *ui.Logger, state *ui.State, window fyne.Window, app fyne
 		select {
 		case err := <-errCh:
 			d.Hide()
-			logger.Log("Saving output", *state, err)
 			if err != nil {
+				logger.Log("Saving output", *state, err)
 				dialog.ShowError(err, window)
 			}
 			err = clearOutputFile(app)
-			logger.Log("Clearing output file", *state, err)
 			if err != nil {
+				logger.Log("Clearing output file", *state, err)
 				dialog.ShowError(err, window)
 			}
 			return


### PR DESCRIPTION
Add debug logs that the user can export to assist with issue reporting.

# Maintaining Privacy

First and foremost, these logs only exist in memory until a user explicitly saves them to a file. They can then be reviewed before being shared for any data the user would prefer to remove.

These logs should not expose any sensitive data if at all avoidable. The only data included is
1. Timestamps (hour, minute, second, milliseconds). This data is useful to see if there are any unexpected pauses or potential race conditions. No timezone or date is recorded.
2. Processing step (`Getting uri`, `Starting encryption`, etc.). This just identifies what line is being logged. This includes leaking some information like if the user created a keyfile.
3. App state. This includes
  i. Reed-Solomon / Paranoid / Deniability check boxes. Needed to check for unintentionally changing state.
  ii. The existence of comments. Logged as either `""` or `"non-empty-string"`.
  iii. Partial file URIs (input file, output file, keyfiles). Only the characters up to the first `:` are kept. The rest are replaced with `redacted-id` where `id` is an incremental counter that tracks each file. This should allow debugging state management and file access without revealing filenames or storage paths on the user's device. It does expose data such the number of keyfiles used. It also exposes the manner in which the device gives access to the data (generic content, file, etc.) which, for my own testing, could separate my mobile device from my pc because they exposed different uri types. This data is necessary for debugging because it shows what type of uri is having issues.
4. Any applicable error message. This is the riskiest field because in theory anything low level could return an error message that will get passed to here, and I do not know how to validate that all possible error messages exclude sensitive data. However, without the error message, all I can say is that the error happened.

# Using Logs

The logs can be saved by selecting the `Send` icon button at the top of the app. A brief description will be shown, with an option to cancel or to save the logs, which will then prompt the user to choose a save location. The saved file can then be uploaded in part or in full to an issues report.

The file format is csv, with the state column saved as json. This should be sufficiently readable for someone reporting an issue to be able to sanity check the logs for any data they would prefer to exclude.  