### PR TITLE
Change layout scaling to reduce flickering

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="0.1.0"
+    package="io.github.picocrypt.PicoGo"
+    platformBuildVersionCode="15"
+    platformBuildVersionName="4.0.4-1406430">
+
+    <uses-sdk
+        android:minSdkVersion="15"
+        android:targetSdkVersion="29" />
+
+    <application
+        android:label="PicoGo"
+        android:icon="@ref/0x7f020000"
+        android:debuggable="true">
+
+        <activity
+            android:theme="@ref/0x1030005"
+            android:label="PicoGo"
+            android:name="org.golang.app.GoNativeActivity"
+            android:configChanges="0x2a0"
+            android:exported="true">
+
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="PicoGo" />
+
+            <intent-filter>
+
+                <action
+                    android:name="android.intent.action.MAIN" />
+
+                <category
+                    android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE" />
+</manifest>
+

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -20,7 +20,9 @@
             android:theme="@ref/0x1030005"
             android:label="PicoGo"
             android:name="org.golang.app.GoNativeActivity"
-            android:configChanges="0x2a0"
+            android:configChanges="keyboardHidden|screenSize"
+            android:windowSoftInputMode="adjustPan"
+            android:screenOrientation="portrait"
             android:exported="true">
 
             <meta-data
@@ -44,4 +46,3 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>
-

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,17 +7,11 @@
     platformBuildVersionCode="15"
     platformBuildVersionName="4.0.4-1406430">
 
-    <uses-sdk
-        android:minSdkVersion="15"
-        android:targetSdkVersion="29" />
-
     <application
         android:label="PicoGo"
-        android:icon="@ref/0x7f020000"
         android:debuggable="true">
 
         <activity
-            android:theme="@ref/0x1030005"
             android:label="PicoGo"
             android:name="org.golang.app.GoNativeActivity"
             android:configChanges="keyboardHidden|screenSize"

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -115,6 +115,7 @@ func NewState(app fyne.App) *State {
 		Settings:        NewSettings(app),
 	}
 
+	state.FileName.Wrapping = fyne.TextWrap(fyne.TextTruncateEllipsis)
 	state.Deniability.OnChanged = func(checked bool) { state.updateComments() }
 
 	state.ReedSolomon.SetChecked(state.Settings.ReedSolomonDefault.Checked)

--- a/picogo.go
+++ b/picogo.go
@@ -598,7 +598,7 @@ func main() {
 		passwordRow,
 		state.WorkBtn,
 	)
-	minSize := body.MinSize()
+	minSize := fyne.NewSize(body.MinSize().Width*1.05, body.MinSize().Height*1.05)
 	w.SetContent(container.NewScroll(container.New(layout.NewVBoxLayout(), body)))
 
 	go func() {
@@ -614,7 +614,7 @@ func main() {
 			//   scale. This is to prevent constant updates to the theme.
 			time.Sleep(time.Second / 10.0)
 			currentSize := w.Canvas().Content().Size()
-			targetScale := min(currentSize.Width/minSize.Width, currentSize.Height/minSize.Height)
+			targetScale := currentSize.Width / minSize.Width
 			currentScale := theme.Scale
 			if targetScale > currentScale*1.01 || targetScale < currentScale*0.99 {
 				theme.Scale = targetScale

--- a/picogo.go
+++ b/picogo.go
@@ -593,9 +593,9 @@ func main() {
 		info_row,
 		picker,
 		fileRow,
+		passwordRow,
 		advSettingsRow,
 		keyfiles,
-		passwordRow,
 		state.WorkBtn,
 	)
 	minSize := fyne.NewSize(body.MinSize().Width*1.05, body.MinSize().Height*1.05)

--- a/picogo.go
+++ b/picogo.go
@@ -599,12 +599,7 @@ func main() {
 		state.WorkBtn,
 	)
 	minSize := body.MinSize()
-	w.SetContent(
-		container.New(
-			layout.NewVBoxLayout(),
-			body,
-		),
-	)
+	w.SetContent(container.NewScroll(container.New(layout.NewVBoxLayout(), body)))
 
 	go func() {
 		for {


### PR DESCRIPTION
The new layout should have the following behavior
- the app will always be in portrait mode
- the scaling is based on just the horizontal width. This does not change when the user pulls up the keyboard
- the password entries are moved higher in the ui to be less likely to be covered by the keyboard
- long file names should not run off of the screen
- slightly increased width padding, hopefully resolving reports of text running into the border