### PR TITLE
Add preview mode for decryption

### DIFF
--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -262,3 +262,13 @@ func (s *State) Clear() {
 		s.ConfirmPassword.SetText("")
 	})
 }
+
+func (s *State) DefaultSaveName() string {
+	if s.input == nil {
+		return ""
+	}
+	if s.IsEncrypting() {
+		return s.input.Name() + ".pcv"
+	}
+	return strings.TrimSuffix(s.input.Name(), ".pcv")
+}

--- a/picogo.go
+++ b/picogo.go
@@ -433,18 +433,24 @@ func decrypt(logger *ui.Logger, state *ui.State, win fyne.Window, app fyne.App) 
 	if save {
 		text := widget.NewLabel(msg)
 		text.Wrapping = fyne.TextWrapWord
-		dialog.ShowCustomConfirm(
+		cancelBtn := widget.NewButton("Cancel", func() {})
+		previewBtn := widget.NewButton("Preview", func() { showPreview(app, state, win, logger) })
+		saveBtn := widget.NewButton("Save", func() {})
+		d := dialog.NewCustomWithoutButtons(
 			"Decryption Complete",
-			"Save",
-			"Cancel",
-			text,
-			func(b bool) {
-				if b {
-					chooseSaveAs(logger, state, win, app, []byte{})
-				}
-			},
+			container.New(
+				layout.NewVBoxLayout(),
+				text,
+				container.New(layout.NewHBoxLayout(), cancelBtn, previewBtn, saveBtn),
+			),
 			win,
 		)
+		cancelBtn.OnTapped = func() { fyne.Do(d.Dismiss) }
+		saveBtn.OnTapped = func() {
+			fyne.Do(d.Dismiss)
+			go func() { chooseSaveAs(logger, state, win, app, []byte{}) }()
+		}
+		fyne.Do(d.Show)
 	} else {
 		dialog.ShowError(errors.New(msg), win)
 	}

--- a/picogo.go
+++ b/picogo.go
@@ -618,7 +618,6 @@ func showImagePreview(app fyne.App, state *ui.State, window fyne.Window, logger 
 	}
 	preview := app.NewWindow("Preview")
 	image := canvas.NewImageFromReader(output, state.Input().Name())
-	image.SetMinSize(fyne.NewSize(400, 400)) // TODO what size should this be?
 	image.FillMode = canvas.ImageFillContain
 	preview.SetContent(image)
 	fyne.Do(preview.Show)

--- a/picogo.go
+++ b/picogo.go
@@ -23,6 +23,10 @@ import (
 	"github.com/picocrypt/picogo/internal/ui"
 )
 
+const (
+	previewTextSize = 5000
+)
+
 func uriReadCloser(uri string) (fyne.URIReadCloser, error) {
 	fullUri, err := storage.ParseURI(uri)
 	if err != nil {
@@ -630,8 +634,8 @@ func showTextPreview(app fyne.App, state *ui.State, window fyne.Window, logger *
 		logger.Log("Failed to open output file", *state, err)
 		return
 	}
-	// Only read the first 1000 bytes to avoid loading too much data into memory
-	rawText, err := io.ReadAll(io.LimitReader(output, 1000))
+	// Only read the N bytes to avoid loading too much data into memory
+	rawText, err := io.ReadAll(io.LimitReader(output, previewTextSize))
 	if err != nil {
 		dialog.ShowError(fmt.Errorf("reading output file: %w", err), window)
 		logger.Log("Failed to read output file", *state, err)

--- a/picogo.go
+++ b/picogo.go
@@ -625,7 +625,8 @@ func showTextPreview(app fyne.App, state *ui.State, window fyne.Window, logger *
 		logger.Log("Failed to open output file", *state, err)
 		return
 	}
-	rawText, err := io.ReadAll(output)
+	// Only read the first 1000 bytes to avoid loading too much data into memory
+	rawText, err := io.ReadAll(io.LimitReader(output, 1000))
 	if err != nil {
 		dialog.ShowError(fmt.Errorf("reading output file: %w", err), window)
 		logger.Log("Failed to read output file", *state, err)


### PR DESCRIPTION
Add preview option for decryption. This lets the user view the file from internal app storage before copying elsewhere.
- files ending with png, jpg, jpeg, and svg are assumed to be images
- all other files are presented as text